### PR TITLE
Implement --drain support using kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,17 @@ COPY . ./
 RUN go install -v .
 
 
+# download kubectl
+FROM buildpack-deps:stretch-curl as kube-dl
+
+RUN curl -L -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.3/bin/linux/amd64/kubectl && install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+
 
 # must match with go-build base image
 FROM debian:stretch
 
+COPY --from=kube-dl /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=go-build /go/bin/pharos-host-upgrades /usr/local/bin/pharos-host-upgrades
 
 CMD ["/usr/local/bin/pharos-host-upgrades"]

--- a/kube.go
+++ b/kube.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/kontena/pharos-host-upgrades/hosts"
 	"github.com/kontena/pharos-host-upgrades/kube"
+	"github.com/kontena/pharos-host-upgrades/kubectl"
 )
 
 const KubeLockAnnotation = "pharos-host-upgrades.kontena.io/lock"
+const KubeDrainAnnotation = "pharos-host-upgrades.kontena.io/drain"
 
 type KubeOptions struct {
 	kube.Options
@@ -19,15 +21,17 @@ func (options KubeOptions) IsSet() bool {
 }
 
 type Kube struct {
-	kube *kube.Kube
-	lock *kube.Lock
-	node *kube.Node
-	host hosts.Host
+	options kube.Options
+	kube    *kube.Kube
+	lock    *kube.Lock
+	node    *kube.Node
+	host    hosts.Host
 }
 
 func makeKube(options Options, host hosts.Host) (Kube, error) {
 	var k = Kube{
-		host: host,
+		options: options.Kube.Options,
+		host:    host,
 	}
 
 	if !options.Kube.IsSet() {
@@ -97,6 +101,14 @@ func (k *Kube) initNode() error {
 		log.Printf("Initialized kube node %v conditions", k.node)
 	}
 
+	if changed, err := k.node.SetSchedulableIfAnnotated(KubeDrainAnnotation); err != nil {
+		return fmt.Errorf("Failed to clear node drain state: %v", err)
+	} else if changed {
+		log.Printf("Uncordoned drained kube node %v (with annotation %v)", k.node, KubeDrainAnnotation)
+	} else {
+		log.Printf("Kube node %v is not marked as drained (with annotation %v)", k.node, KubeDrainAnnotation)
+	}
+
 	return nil
 }
 
@@ -150,4 +162,16 @@ func (k Kube) UpdateHostStatus(status hosts.Status, upgradeErr error) error {
 	}
 
 	return nil
+}
+
+func (k Kube) DrainNode() error {
+	if k.node == nil {
+		return fmt.Errorf("No --kube-node configured")
+	} else if err := k.node.SetAnnotation(KubeDrainAnnotation, "true"); err != nil {
+		return fmt.Errorf("Failed to set node annotation for drain: %v", err)
+	} else if err := kubectl.Drain(k.options.Node); err != nil {
+		return fmt.Errorf("Failed to drain node %v: %v", k.options.Node, err)
+	} else {
+		return nil
+	}
 }

--- a/kube.go
+++ b/kube.go
@@ -165,6 +165,8 @@ func (k Kube) UpdateHostStatus(status hosts.Status, upgradeErr error) error {
 }
 
 func (k Kube) DrainNode() error {
+	log.Printf("Draining kube node %v (with annotation %v)...", k.node, KubeDrainAnnotation)
+
 	if k.node == nil {
 		return fmt.Errorf("No --kube-node configured")
 	} else if err := k.node.SetAnnotation(KubeDrainAnnotation, "true"); err != nil {

--- a/kube.go
+++ b/kube.go
@@ -8,6 +8,8 @@ import (
 	"github.com/kontena/pharos-host-upgrades/kube"
 )
 
+const KubeLockAnnotation = "pharos-host-upgrades.kontena.io/lock"
+
 type KubeOptions struct {
 	kube.Options
 }
@@ -57,7 +59,7 @@ func makeKube(options Options, host hosts.Host) (Kube, error) {
 }
 
 func (k *Kube) initLock() error {
-	if kubeLock, err := k.kube.Lock(); err != nil {
+	if kubeLock, err := k.kube.Lock(KubeLockAnnotation); err != nil {
 		return err
 	} else {
 		k.lock = kubeLock

--- a/kube/kube.go
+++ b/kube/kube.go
@@ -43,11 +43,11 @@ func (kube *Kube) Node() (*Node, error) {
 	return &node, nil
 }
 
-func (kube *Kube) Lock() (*Lock, error) {
+func (kube *Kube) Lock(annotation string) (*Lock, error) {
 	var lock = Lock{
 		namespace:  kube.options.Namespace,
 		name:       kube.options.DaemonSet,
-		annotation: LockAnnotation,
+		annotation: annotation,
 		value:      kube.options.Node,
 	}
 

--- a/kube/lock.go
+++ b/kube/lock.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-const LockAnnotation = "pharos-host-upgrades.kontena.io/lock"
-
 type Lock struct {
 	client     appsv1client.AppsV1Interface
 	namespace  string

--- a/kubectl/drain.go
+++ b/kubectl/drain.go
@@ -1,0 +1,5 @@
+package kubectl
+
+func Drain(node string) error {
+	return kubectl("drain", "--ignore-daemonsets", "--force", node)
+}

--- a/kubectl/exec.go
+++ b/kubectl/exec.go
@@ -1,0 +1,24 @@
+package kubectl
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+func kubectl(args ...string) error {
+	var cmd = exec.Command("kubectl", args...)
+
+	log.Printf("kubectl %v...", strings.Join(args, " "))
+
+	if out, err := cmd.Output(); err == nil {
+		log.Printf("kubectl %v: %v", strings.Join(args, " "), string(out))
+
+		return nil
+	} else if exitErr, ok := err.(*exec.ExitError); ok {
+		return fmt.Errorf("kubectl %v: %v: %v", strings.Join(args, " "), exitErr.String(), string(exitErr.Stderr))
+	} else {
+		return err
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ type Options struct {
 	Schedule      string
 	Reboot        bool
 	RebootTimeout time.Duration
+	Drain         bool
 	Kube          KubeOptions
 }
 
@@ -69,7 +70,17 @@ func run(options Options) error {
 			}
 
 			if options.Reboot && status.RebootRequired {
-				log.Printf("Rebooting host...")
+				if !options.Drain {
+					log.Printf("Rebooting host without kube --drain...")
+				} else {
+					log.Printf("Reboot required, draining kube node...")
+
+					if err := kube.DrainNode(); err != nil {
+						return false, fmt.Errorf("Failed to drain kube node for host reboot: %v", err)
+					}
+
+					log.Printf("Kube node drained, rebooting...")
+				}
 
 				if err := host.Reboot(); err != nil {
 					return false, fmt.Errorf("Failed to reboot host: %v", err)
@@ -80,14 +91,18 @@ func run(options Options) error {
 				return true, nil // do not release kube lock
 
 			} else if status.RebootRequired {
-				log.Printf("Skipping host reboot...")
+				log.Printf("Reboot required, but skipping without --reboot")
+
+			} else {
+				log.Printf("No reboot required")
 			}
 
 			return false, nil
 		}()
 
+		// either release lock, or wait for reboot to happen
 		if err != nil {
-			log.Printf("Upgrade failed, releasing kube lock...")
+			log.Printf("Upgrade failed, releasing kube lock... (%v)", err)
 
 			if lockErr := kube.ReleaseLock(); lockErr != nil {
 				log.Printf("Failed to release kube lock: %v", lockErr)
@@ -102,8 +117,10 @@ func run(options Options) error {
 			time.Sleep(options.RebootTimeout)
 
 			return fmt.Errorf("Timeout waiting for host to shutdown")
+
 		} else if err := kube.ReleaseLock(); err != nil {
 			return fmt.Errorf("Failed to release kube lock: %v", err)
+
 		} else {
 			log.Printf("Released kube lock")
 		}
@@ -120,6 +137,8 @@ func main() {
 	flag.StringVar(&options.Schedule, "schedule", "", "Scheduled upgrade (cron syntax)")
 	flag.BoolVar(&options.Reboot, "reboot", false, "Reboot if required")
 	flag.DurationVar(&options.RebootTimeout, "reboot-timeout", DefaultRebootTimeout, "Wait for system to shutdown when rebooting")
+	flag.BoolVar(&options.Drain, "drain", false, "Drain kube node before reboot, uncordon after reboot")
+
 	flag.StringVar(&options.Kube.Namespace, "kube-namespace", os.Getenv("KUBE_NAMESPACE"), "Name of kube Namespace (KUBE_NAMESPACE)")
 	flag.StringVar(&options.Kube.DaemonSet, "kube-daemonset", os.Getenv("KUBE_DAEMONSET"), "Name of kube DaemonSet (KUBE_DAEMONSET)")
 	flag.StringVar(&options.Kube.Node, "kube-node", os.Getenv("KUBE_NODE"), "Name of kube Node (KUBE_NODE)")

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func run(options Options) error {
 	}
 
 	if options.Reboot && options.Drain {
-		log.Printf("Using --reboot --drain, will drain and reboot host after upgrades if required")
+		log.Printf("Using --reboot --drain, will drain kube node and reboot host after upgrades if required")
 	} else if options.Reboot {
 		log.Printf("Using --reboot, will reboot host after upgrades if required")
 	} else {

--- a/resources/clusterrole.yml
+++ b/resources/clusterrole.yml
@@ -31,3 +31,32 @@ rules:
   - nodes/status
   verbs:
   - update
+
+# drain
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create

--- a/resources/daemonset.yml
+++ b/resources/daemonset.yml
@@ -22,6 +22,8 @@ spec:
             - pharos-host-upgrades
           args:
             - "--schedule=0 * * * *"
+            - --reboot
+            - --drain
           env:
             - name: KUBE_NAMESPACE
               valueFrom:


### PR DESCRIPTION
Bundle kubectl 1.10.3 in the Docker image for `kubectl drain ...` support.

Implement `--drain` by running `kubectl drain` for the node before reboot, setting a `pharos-host-upgrades.kontena.io/drain` annotation. Uncordon (clear `.Spec.Unschedulable`) the node after reboot if the `pharos-host-upgrades.kontena.io/drain` annotation is set.

