### PR TITLE
Track kube node reboot status

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -9,21 +9,21 @@ import (
 	"github.com/kontena/pharos-host-upgrades/hosts/ubuntu"
 )
 
-func probeHost(options Options) (hosts.Host, error) {
-	var hosts = []hosts.Host{
+func probeHost(options Options) (hosts.Host, hosts.Info, error) {
+	var probeHosts = []hosts.Host{
 		&ubuntu.Host{},
 		&centos.Host{},
 	}
 
-	for _, host := range hosts {
-		if ok := host.Probe(); !ok {
+	for _, host := range probeHosts {
+		if info, ok := host.Probe(); !ok {
 			continue
 		} else {
 			log.Printf("Probed host: %v", host)
 
-			return host, nil
+			return host, info, nil
 		}
 	}
 
-	return nil, fmt.Errorf("No hosts matched")
+	return nil, hosts.Info{}, fmt.Errorf("No hosts matched")
 }

--- a/hosts/centos/host.go
+++ b/hosts/centos/host.go
@@ -31,15 +31,15 @@ type Host struct {
 	scriptPath string
 }
 
-func (host *Host) Probe() bool {
+func (host *Host) Probe() (hosts.Info, bool) {
 	if hi, err := systemd.GetHostInfo(); err != nil {
 		log.Printf("hosts/centos probe failed: %v", err)
 
-		return false
+		return host.info, false
 	} else if match := osPrettyNameRegexp.FindStringSubmatch(hi.OperatingSystemPrettyName); match == nil {
 		log.Printf("hosts/centos probe mismatch: %v", hi.OperatingSystemPrettyName)
 
-		return false
+		return host.info, false
 	} else {
 		host.info = hosts.Info{
 			OperatingSystem:        OperatingSystem,
@@ -58,15 +58,12 @@ func (host *Host) Probe() bool {
 
 		log.Printf("hosts/centos probe success: %#v", host.info)
 
-		return true
+		return host.info, true
 	}
 }
 
 func (host *Host) String() string {
 	return fmt.Sprintf("%v %v", host.info.OperatingSystem, host.info.OperatingSystemRelease)
-}
-func (host *Host) Info() hosts.Info {
-	return host.info
 }
 
 func (host *Host) Config(config hosts.Config) error {

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -4,6 +4,7 @@ import (
 	"time"
 )
 
+// Static host information, determined during probe, not expected to change without restarting
 type Info struct {
 	OperatingSystem        string
 	OperatingSystemRelease string
@@ -21,8 +22,7 @@ type Status struct {
 }
 
 type Host interface {
-	Probe() bool
-	Info() Info
+	Probe() (Info, bool)
 	Config(Config) error
 	Upgrade() (Status, error)
 	Reboot() error

--- a/hosts/ubuntu/host.go
+++ b/hosts/ubuntu/host.go
@@ -51,15 +51,15 @@ type Host struct {
 	scriptPath    string
 }
 
-func (host *Host) Probe() bool {
+func (host *Host) Probe() (hosts.Info, bool) {
 	if hi, err := systemd.GetHostInfo(); err != nil {
 		log.Printf("hosts/ubuntu probe failed: %v", err)
 
-		return false
+		return host.info, false
 	} else if match := osPrettyNameRegexp.FindStringSubmatch(hi.OperatingSystemPrettyName); match == nil {
 		log.Printf("hosts/ubuntu probe mismatch: %v", hi.OperatingSystemPrettyName)
 
-		return false
+		return host.info, false
 	} else {
 		host.info = hosts.Info{
 			OperatingSystem:        OperatingSystem,
@@ -78,16 +78,12 @@ func (host *Host) Probe() bool {
 
 		log.Printf("hosts/ubuntu probe success: %#v", host.info)
 
-		return true
+		return host.info, true
 	}
 }
 
 func (host *Host) String() string {
 	return fmt.Sprintf("%v %v", host.info.OperatingSystem, host.info.OperatingSystemRelease)
-}
-
-func (host *Host) Info() hosts.Info {
-	return host.info
 }
 
 func (host *Host) Config(config hosts.Config) error {

--- a/kube.go
+++ b/kube.go
@@ -21,17 +21,17 @@ func (options KubeOptions) IsSet() bool {
 }
 
 type Kube struct {
-	options kube.Options
-	kube    *kube.Kube
-	lock    *kube.Lock
-	node    *kube.Node
-	host    hosts.Host
+	options  kube.Options
+	kube     *kube.Kube
+	lock     *kube.Lock
+	node     *kube.Node
+	hostInfo hosts.Info
 }
 
-func makeKube(options Options, host hosts.Host) (Kube, error) {
+func makeKube(options Options, hostInfo hosts.Info) (Kube, error) {
 	var k = Kube{
-		options: options.Kube.Options,
-		host:    host,
+		options:  options.Kube.Options,
+		hostInfo: hostInfo,
 	}
 
 	if !options.Kube.IsSet() {
@@ -156,7 +156,7 @@ func (k Kube) UpdateHostStatus(status hosts.Status, upgradeErr error) error {
 
 	if err := k.node.SetCondition(
 		MakeUpgradeCondition(status, upgradeErr),
-		MakeRebootCondition(status, k.host.Info(), upgradeErr),
+		MakeRebootCondition(status, k.hostInfo, upgradeErr),
 	); err != nil {
 		log.Printf("Failed to update node %v condition: %v", k.node, err)
 	}

--- a/kube.go
+++ b/kube.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/kontena/pharos-host-upgrades/hosts"
 	"github.com/kontena/pharos-host-upgrades/kube"
@@ -11,6 +13,7 @@ import (
 
 const KubeLockAnnotation = "pharos-host-upgrades.kontena.io/lock"
 const KubeDrainAnnotation = "pharos-host-upgrades.kontena.io/drain"
+const KubeRebootAnnotation = "pharos-host-upgrades.kontena.io/reboot"
 
 type KubeOptions struct {
 	kube.Options
@@ -22,10 +25,10 @@ func (options KubeOptions) IsSet() bool {
 
 type Kube struct {
 	options  kube.Options
+	hostInfo hosts.Info
 	kube     *kube.Kube
 	lock     *kube.Lock
 	node     *kube.Node
-	hostInfo hosts.Info
 }
 
 func makeKube(options Options, hostInfo hosts.Info) (*Kube, error) {
@@ -51,35 +54,30 @@ func makeKube(options Options, hostInfo hosts.Info) (*Kube, error) {
 		k.kube = kube
 	}
 
-	if err := k.initLock(); err != nil {
-		return nil, err
-	}
-
 	if err := k.initNode(); err != nil {
 		return nil, err
 	}
 
+	if err := k.initLock(); err != nil {
+		return nil, err
+	}
+
+	// verifies host <=> node state, fails if not rebooted
+	if err := k.clearNodeReboot(); err != nil {
+		return nil, err
+	}
+
+	// this happens even without the reboot annotation set, we do not want to leave the node drained in case of errors
+	if err := k.clearNodeDrain(); err != nil {
+		return nil, err
+	}
+
+	// clear lock if acquired, assuming that host is now in a good state (rebooted, undrained)
+	if err := k.clearLock(); err != nil {
+		return nil, err
+	}
+
 	return &k, nil
-}
-
-func (k *Kube) initLock() error {
-	if kubeLock, err := k.kube.Lock(KubeLockAnnotation); err != nil {
-		return err
-	} else {
-		k.lock = kubeLock
-	}
-
-	if value, acquired, err := k.lock.Test(); err != nil {
-		return fmt.Errorf("Failed to test lock %v: %v", k.lock, err)
-	} else if !acquired {
-		log.Printf("Using kube lock %v (not acquired, value=%v)", k.lock, value)
-	} else if err := k.lock.Release(); err != nil {
-		return fmt.Errorf("Failed to release lock %v: %v", k.lock, err)
-	} else {
-		log.Printf("Released kube lock %v (value=%v)", k.lock, value)
-	}
-
-	return nil
 }
 
 func (k *Kube) initNode() error {
@@ -89,24 +87,85 @@ func (k *Kube) initNode() error {
 		k.node = kubeNode
 	}
 
-	if exists, err := k.node.HasCondition(UpgradeConditionType); err != nil {
-		return fmt.Errorf("Failed to check node %v condition: %v", k.node, err)
-	} else if exists {
-		log.Printf("Found kube node %v with existing conditions", k.node)
-	} else if err := k.node.InitCondition(UpgradeConditionType); err != nil {
-		return fmt.Errorf("Failed to initialize node %v condition %v: %v", k.node, UpgradeConditionType, err)
-	} else if err := k.node.InitCondition(RebootConditionType); err != nil {
-		return fmt.Errorf("Failed to initialize node %v condition %v: %v", k.node, RebootConditionType, err)
+	return nil
+}
+
+func (k *Kube) initLock() error {
+	if kubeLock, err := k.kube.Lock(KubeLockAnnotation); err != nil {
+		return err
 	} else {
-		log.Printf("Initialized kube node %v conditions", k.node)
+		k.lock = kubeLock
 	}
 
+	return nil
+}
+
+func (k *Kube) checkReboot() (time.Time, bool, error) {
+	var t time.Time
+
+	if value, exists, err := k.node.GetAnnotation(KubeRebootAnnotation); err != nil {
+		return t, false, fmt.Errorf("Faield to get node reboot annotation: %v", err)
+	} else if !exists {
+		return t, false, nil
+	} else if err := json.Unmarshal([]byte(value), &t); err != nil {
+		return t, true, fmt.Errorf("Failed to unmarshal reboot annotation: %v", err)
+	} else {
+		return t, true, nil
+	}
+}
+
+// check and clear node reboot state/status
+// fails if expected to reboot, but did not reboot
+func (k *Kube) clearNodeReboot() error {
+	if rebootTime, rebooting, err := k.checkReboot(); err != nil {
+		return err
+
+	} else if !rebooting {
+		log.Printf("Initialized kube node %v (not rebooting)", k.node)
+
+		return nil
+
+	} else if !k.hostInfo.BootTime.After(rebootTime) {
+		return fmt.Errorf("Kube node %v is still rebooting (reboot=%v >= boot=%v)", k.node, rebootTime, k.hostInfo.BootTime)
+
+	} else if err := k.node.SetCondition(MakeRebootConditionRebooted(k.hostInfo.BootTime)); err != nil {
+		log.Printf("Failed to update node %v condition: %v", k.node, err)
+
+		return nil
+
+	} else if err := k.node.ClearAnnotation(KubeRebootAnnotation); err != nil {
+		return fmt.Errorf("Failed to clear reboot annotation: %v", err)
+
+	} else {
+		log.Printf("Kube node %v was rebooted (reboot=%v < boot=%v)...", k.node, rebootTime, k.hostInfo.BootTime)
+
+		return nil
+	}
+}
+
+// uncordon if drained before reboot
+func (k *Kube) clearNodeDrain() error {
 	if changed, err := k.node.SetSchedulableIfAnnotated(KubeDrainAnnotation); err != nil {
 		return fmt.Errorf("Failed to clear node drain state: %v", err)
 	} else if changed {
 		log.Printf("Uncordoned drained kube node %v (with annotation %v)", k.node, KubeDrainAnnotation)
+		return nil
 	} else {
 		log.Printf("Kube node %v is not marked as drained (with annotation %v)", k.node, KubeDrainAnnotation)
+		return nil
+	}
+}
+
+// release lock if still acquired
+func (k *Kube) clearLock() error {
+	if value, acquired, err := k.lock.Test(); err != nil {
+		return fmt.Errorf("Failed to test lock %v: %v", k.lock, err)
+	} else if !acquired {
+		log.Printf("Using kube lock %v (not acquired, value=%v)", k.lock, value)
+	} else if err := k.lock.Release(); err != nil {
+		return fmt.Errorf("Failed to release lock %v: %v", k.lock, err)
+	} else {
+		log.Printf("Released kube lock %v (value=%v)", k.lock, value)
 	}
 
 	return nil
@@ -134,17 +193,6 @@ func (k *Kube) ReleaseLock() error {
 	return k.lock.Release()
 }
 
-func (k *Kube) WithLock(f func() error) error {
-	if k == nil || k.lock == nil {
-		log.Printf("Skip kube locking")
-		return f()
-	}
-
-	log.Printf("Acquiring kube lock...")
-
-	return k.lock.With(f)
-}
-
 // Update node status condition based on function execution
 func (k *Kube) UpdateHostStatus(status hosts.Status, upgradeErr error) error {
 	if k == nil || k.node == nil {
@@ -156,7 +204,7 @@ func (k *Kube) UpdateHostStatus(status hosts.Status, upgradeErr error) error {
 
 	if err := k.node.SetCondition(
 		MakeUpgradeCondition(status, upgradeErr),
-		MakeRebootCondition(status, k.hostInfo, upgradeErr),
+		MakeRebootCondition(k.hostInfo, status, upgradeErr),
 	); err != nil {
 		log.Printf("Failed to update node %v condition: %v", k.node, err)
 	}
@@ -175,6 +223,25 @@ func (k *Kube) DrainNode() error {
 		return fmt.Errorf("Failed to set node annotation for drain: %v", err)
 	} else if err := kubectl.Drain(k.options.Node); err != nil {
 		return fmt.Errorf("Failed to drain node %v: %v", k.options.Node, err)
+	} else {
+		return nil
+	}
+}
+
+func (k *Kube) MarkReboot(rebootTime time.Time) error {
+	if k == nil || k.node == nil {
+		log.Printf("Skip kube node reboot marking")
+		return nil
+	}
+
+	log.Printf("Marking kube node %v for reboot (with annotation %v=%v)...", k.node, KubeRebootAnnotation, rebootTime)
+
+	if value, err := json.Marshal(rebootTime); err != nil {
+		return fmt.Errorf("Failed to marshal reboot annotation: %v", err)
+	} else if err := k.node.SetAnnotation(KubeRebootAnnotation, string(value)); err != nil {
+		return fmt.Errorf("Failed to set node annotation for reboot: %v", err)
+	} else if err := k.node.SetCondition(MakeRebootConditionRebooting(rebootTime)); err != nil {
+		return fmt.Errorf("Failed to set node condition for reboot: %v", err)
 	} else {
 		return nil
 	}

--- a/kube_conditions.go
+++ b/kube_conditions.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -34,7 +36,7 @@ func MakeUpgradeCondition(status hosts.Status, err error) corev1.NodeCondition {
 	return condition
 }
 
-func MakeRebootCondition(status hosts.Status, info hosts.Info, upgradeErr error) corev1.NodeCondition {
+func MakeRebootCondition(info hosts.Info, status hosts.Status, upgradeErr error) corev1.NodeCondition {
 	var condition = corev1.NodeCondition{
 		Type:              RebootConditionType,
 		LastHeartbeatTime: metav1.Now(),
@@ -55,6 +57,32 @@ func MakeRebootCondition(status hosts.Status, info hosts.Info, upgradeErr error)
 		condition.Reason = "UpToDate"
 		condition.Message = status.RebootRequiredMessage
 	}
+
+	return condition
+}
+
+func MakeRebootConditionRebooting(rebootTime time.Time) corev1.NodeCondition {
+	var condition = corev1.NodeCondition{
+		Type:              RebootConditionType,
+		LastHeartbeatTime: metav1.Now(),
+	}
+
+	condition.Status = corev1.ConditionTrue
+	condition.LastTransitionTime = metav1.NewTime(rebootTime)
+	condition.Reason = "Rebooting"
+
+	return condition
+}
+
+func MakeRebootConditionRebooted(bootTime time.Time) corev1.NodeCondition {
+	var condition = corev1.NodeCondition{
+		Type:              RebootConditionType,
+		LastHeartbeatTime: metav1.Now(),
+	}
+
+	condition.Status = corev1.ConditionFalse
+	condition.LastTransitionTime = metav1.NewTime(bootTime)
+	condition.Reason = "Rebooted"
 
 	return condition
 }

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func run(options Options) error {
 		return fmt.Errorf("Failed to load config: %v", err)
 	}
 
-	host, err := probeHost(options)
+	host, hostInfo, err := probeHost(options)
 	if err != nil {
 		return fmt.Errorf("Failed to probe host: %v", err)
 	}
@@ -35,7 +35,7 @@ func run(options Options) error {
 		return fmt.Errorf("Failed to configure host: %v", err)
 	}
 
-	kube, err := makeKube(options, host)
+	kube, err := makeKube(options, hostInfo)
 	if err != nil {
 		return fmt.Errorf("Failed to connect to kube: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func run(options Options) error {
 		return fmt.Errorf("Failed to configure host: %v", err)
 	}
 
+	// kube is optional, this will be nil if not configured; the methods are no-op when called on nil
 	kube, err := makeKube(options, hostInfo)
 	if err != nil {
 		return fmt.Errorf("Failed to connect to kube: %v", err)
@@ -124,7 +125,7 @@ func run(options Options) error {
 			return fmt.Errorf("Failed to release kube lock: %v", err)
 
 		} else {
-			log.Printf("Released kube lock")
+			log.Printf("Done")
 		}
 
 		return nil


### PR DESCRIPTION
Fixes #19

Use a `pharos-host-upgrades.kontena.io/reboot` annotation timestamp vs the node info `BootTime` timestamp to track the node reboot state across restarts.

The `HostUpgradesReboot` condition is updated through the `RebootRequired` => `Rebooting` => `Rebooted` states.

The reboot annotation also guards against spurious restarts during the reboot:

```
2018/05/30 13:47:34 Failed to initialize kube: Kube node ubuntu-xenial is still rebooting (reboot=2018-05-30 13:09:26.719129811 +0000 UTC >= boot=2018-05-30 13:05:14 +0000 UTC)
```