### PR TITLE
Retry kube lock acquire until --schedule-window expires

### DIFF
--- a/kube.go
+++ b/kube.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -171,7 +172,7 @@ func (k *Kube) clearLock() error {
 	return nil
 }
 
-func (k *Kube) AcquireLock() error {
+func (k *Kube) AcquireLock(ctx context.Context) error {
 	if k == nil || k.lock == nil {
 		log.Printf("Skip kube locking")
 		return nil
@@ -179,7 +180,7 @@ func (k *Kube) AcquireLock() error {
 
 	log.Printf("Acquiring kube lock...")
 
-	return k.lock.Acquire()
+	return k.lock.Acquire(ctx)
 }
 
 func (k *Kube) ReleaseLock() error {

--- a/kube/lock.go
+++ b/kube/lock.go
@@ -164,6 +164,7 @@ func (lock *Lock) modify(ctx context.Context, fn func(*runtime.Object) error) er
 		} else if err := fn(&object); err != nil {
 			return err
 		} else if err := lock.update(&object); err != nil && errors.IsConflict(err) {
+			log.Printf("kube/lock %v: retry modify conflict: %v", lock, err)
 			// retry
 		} else if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func run(options Options) error {
 	}
 
 	return scheduler.Run(func(ctx context.Context) error {
-		if err := kube.AcquireLock(); err != nil {
+		if err := kube.AcquireLock(ctx); err != nil {
 			return fmt.Errorf("Failed to acquire kube lock: %v", err)
 		}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -9,15 +10,17 @@ import (
 )
 
 const DefaultRebootTimeout = 5 * time.Minute
+const DefaultScheduleWindow = 1 * time.Hour
 
 type Options struct {
-	ConfigPath    string
-	HostMount     string
-	Schedule      string
-	Reboot        bool
-	RebootTimeout time.Duration
-	Drain         bool
-	Kube          KubeOptions
+	ConfigPath     string
+	HostMount      string
+	Schedule       string
+	ScheduleWindow time.Duration
+	Reboot         bool
+	RebootTimeout  time.Duration
+	Drain          bool
+	Kube           KubeOptions
 }
 
 func run(options Options) error {
@@ -54,11 +57,12 @@ func run(options Options) error {
 		log.Printf("Skipping host reboot after upgrades")
 	}
 
-	return scheduler.Run(func() error {
+	return scheduler.Run(func(ctx context.Context) error {
 		if err := kube.AcquireLock(); err != nil {
 			return fmt.Errorf("Failed to acquire kube lock: %v", err)
 		}
 
+		// runs with the kube lock held
 		rebooting, err := func() (bool, error) {
 			log.Printf("Running host upgrades...")
 
@@ -146,6 +150,7 @@ func main() {
 	flag.StringVar(&options.ConfigPath, "config-path", "/etc/host-upgrades", "Path to configmap dir")
 	flag.StringVar(&options.HostMount, "host-mount", "/run/host-upgrades", "Path to shared mount with host. Must be under /run to reset when rebooting!")
 	flag.StringVar(&options.Schedule, "schedule", "", "Scheduled upgrade (cron syntax)")
+	flag.DurationVar(&options.ScheduleWindow, "schedule-window", DefaultScheduleWindow, "Set a deadline for the scheduled upgrade to start (duration syntax)")
 	flag.BoolVar(&options.Reboot, "reboot", false, "Reboot if required")
 	flag.DurationVar(&options.RebootTimeout, "reboot-timeout", DefaultRebootTimeout, "Wait for system to shutdown when rebooting")
 	flag.BoolVar(&options.Drain, "drain", false, "Drain kube node before reboot, uncordon after reboot")

--- a/resources/daemonset.yml
+++ b/resources/daemonset.yml
@@ -22,6 +22,7 @@ spec:
             - pharos-host-upgrades
           args:
             - "--schedule=0 * * * *"
+            - --schedule-window=30s
             - --reboot
             - --drain
           env:


### PR DESCRIPTION
Run each scheduled task with a `context.Context`, using the `--schedule-window=1h` option to set a deadline for the task execution.

Fixes #1: `kube/Lock.Acquire` takes a `context.Context` and times out if the lock is not freed before the context expires.

This required re-implementing the `k8s.io/client-go/util/retry/RetryOnConflict` due to a bug with watch timeout errors, which caused the upgrades to run without the lock held in case the `Acquire` => `retry` => `wait` timed out: https://github.com/kubernetes/client-go/issues/427

Fixes #20: the top-level `Kube.AcquireLock()` retries the `kube/Lock.Acquire` until it either succeeds, or the context deadline expires. This also handles the master being down, with crude exponential backoff.