### PR TITLE
Use drone for Docker image build/deploy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,7 @@
+workspace:
+  base: /go
+  path: src/github.com/kontena/pharos-host-upgrades
+
 pipeline:
   test:
     image: golang:1.10

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   # build and deploy quay.io/kontena/pharos-host-upgrades:edge from master branch
-  docker:
+  docker-edge:
     registry: quay.io
     image: plugins/docker
     secrets: [ docker_username, docker_password ]
@@ -9,3 +9,13 @@ pipeline:
     dockerfile: Dockerfile
     when:
       branch: master
+
+  docker:
+    registry: quay.io
+    image: plugins/docker
+    secrets: [ docker_username, docker_password ]
+    repo: quay.io/kontena/pharos-host-upgrades
+    dockerfile: Dockerfile
+    auto_tag: true
+    when:
+      event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,12 @@
 pipeline:
+  test:
+    image: golang:1.10
+    commands:
+      - curl -L -o /tmp/dep-linux-amd64 https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 && install -m 0755 /tmp/dep-linux-amd64 /usr/local/bin/dep
+      - apt-get update && apt-get install -y libsystemd-dev
+      - dep ensure -vendor-only
+      - go test -v ./...
+
   # build and deploy quay.io/kontena/pharos-host-upgrades:edge from master branch
   docker-edge:
     registry: quay.io

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,19 +11,20 @@ pipeline:
   docker-edge:
     registry: quay.io
     image: plugins/docker
+    dockerfile: Dockerfile
     secrets: [ docker_username, docker_password ]
     repo: quay.io/kontena/pharos-host-upgrades
     tags: edge
-    dockerfile: Dockerfile
     when:
       branch: master
 
+  # build and deploy quay.io/kontena/pharos-host-upgrades:latest from master branch tags
   docker:
     registry: quay.io
     image: plugins/docker
+    dockerfile: Dockerfile
     secrets: [ docker_username, docker_password ]
     repo: quay.io/kontena/pharos-host-upgrades
-    dockerfile: Dockerfile
     auto_tag: true
     when:
       event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,11 @@
+pipeline:
+  # build and deploy quay.io/kontena/pharos-host-upgrades:edge from master branch
+  docker:
+    registry: quay.io
+    image: plugins/docker
+    secrets: [ docker_username, docker_password ]
+    repo: quay.io/kontena/pharos-host-upgrades
+    tags: edge
+    dockerfile: Dockerfile
+    when:
+      branch: master


### PR DESCRIPTION
Fixes #16 

Build and deploy `quay.io/kontena/pharos-host-upgrades:edge` images from the git master branch.

TODO  #24 arm64 builds... I'd like to see the amd64 builds working first, though.