### PR TITLE
Cross-compile arm64 images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,20 +11,18 @@ pipeline:
       - dep ensure -vendor-only
       - go test -v ./...
 
-  # build and deploy quay.io/kontena/pharos-host-upgrades:edge from master branch
-  docker-edge:
+  # build and deploy quay.io/kontena/pharos-host-upgrades-amd64:edge from master branch
+  docker-edge-amd64:
     registry: quay.io
     image: plugins/docker
     dockerfile: Dockerfile
     secrets: [ docker_username, docker_password ]
-    repo: quay.io/kontena/pharos-host-upgrades
-    tags:
-      - edge
-      - edge-linux-amd64
+    repo: quay.io/kontena/pharos-host-upgrades-amd64
+    tags: edge
     when:
       branch: master
 
-  # build and deploy quay.io/kontena/pharos-host-upgrades:edge from master branch
+  # build and deploy quay.io/kontena/pharos-host-upgrades-arm64:edge from master branch
   docker-edge-arm64:
     registry: quay.io
     image: plugins/docker
@@ -32,26 +30,24 @@ pipeline:
     build_args:
       - ARCH=arm64
     secrets: [ docker_username, docker_password ]
-    repo: quay.io/kontena/pharos-host-upgrades
-    tags:
-      - edge-linux-arm64
+    repo: quay.io/kontena/pharos-host-upgrades-arm64
+    tags: edge
     when:
       branch: master
 
 
-  # build and deploy quay.io/kontena/pharos-host-upgrades:latest-linux-amd64 from master branch tags
+  # build and deploy quay.io/kontena/pharos-host-upgrades-amd64:latest from master branch tags
   docker-amd64:
     registry: quay.io
     image: plugins/docker
     dockerfile: Dockerfile
     secrets: [ docker_username, docker_password ]
-    repo: quay.io/kontena/pharos-host-upgrades
+    repo: quay.io/kontena/pharos-host-upgrades-amd64
     auto_tag: true
-    auto_tag_suffix: linux-amd64
     when:
       event: tag
 
-  # build and deploy quay.io/kontena/pharos-host-upgrades:latest-linux-arm64 from master branch tags
+  # build and deploy quay.io/kontena/pharos-host-upgrades-arm46:latest from master branch tags
   docker-arm64:
     registry: quay.io
     image: plugins/docker
@@ -59,8 +55,7 @@ pipeline:
     build_args:
       - ARCH=arm64
     secrets: [ docker_username, docker_password ]
-    repo: quay.io/kontena/pharos-host-upgrades
+    repo: quay.io/kontena/pharos-host-upgrades-arm64
     auto_tag: true
-    auto_tag_suffix: linux-arm64
     when:
       event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,17 +18,49 @@ pipeline:
     dockerfile: Dockerfile
     secrets: [ docker_username, docker_password ]
     repo: quay.io/kontena/pharos-host-upgrades
-    tags: edge
+    tags:
+      - edge
+      - edge-linux-amd64
     when:
       branch: master
 
-  # build and deploy quay.io/kontena/pharos-host-upgrades:latest from master branch tags
-  docker:
+  # build and deploy quay.io/kontena/pharos-host-upgrades:edge from master branch
+  docker-edge-arm64:
+    registry: quay.io
+    image: plugins/docker
+    dockerfile: Dockerfile.cross
+    build_args:
+      - ARCH=arm64
+    secrets: [ docker_username, docker_password ]
+    repo: quay.io/kontena/pharos-host-upgrades
+    tags:
+      - edge-linux-arm64
+    when:
+      branch: master
+
+
+  # build and deploy quay.io/kontena/pharos-host-upgrades:latest-linux-amd64 from master branch tags
+  docker-amd64:
     registry: quay.io
     image: plugins/docker
     dockerfile: Dockerfile
     secrets: [ docker_username, docker_password ]
     repo: quay.io/kontena/pharos-host-upgrades
     auto_tag: true
+    auto_tag_suffix: linux-amd64
+    when:
+      event: tag
+
+  # build and deploy quay.io/kontena/pharos-host-upgrades:latest-linux-arm64 from master branch tags
+  docker-arm64:
+    registry: quay.io
+    image: plugins/docker
+    dockerfile: Dockerfile.cross
+    build_args:
+      - ARCH=arm64
+    secrets: [ docker_username, docker_password ]
+    repo: quay.io/kontena/pharos-host-upgrades
+    auto_tag: true
+    auto_tag_suffix: linux-arm64
     when:
       event: tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10.2 as go-build
 
-RUN curl -L -o /tmp/dep-linux-amd64 https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 && install -m 0755 /tmp/dep-linux-amd64 /usr/local/bin/dep
+RUN curl -L -o /tmp/dep https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 && install -m 0755 /tmp/dep /usr/local/bin/dep
 RUN apt-get update && apt-get install -y \
   libsystemd-dev
 

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,0 +1,35 @@
+# Cross-architecture builds
+# builds without CGO => reduced featureset
+ARG BUILD_ARCH=amd64
+ARG ARCH=amd64
+
+FROM golang:1.10.2 as go-build
+ARG ARCH
+ARG BUILD_ARCH
+
+RUN curl -L -o /tmp/dep https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-${BUILD_ARCH} && install -m 0755 /tmp/dep /usr/local/bin/dep
+
+WORKDIR /go/src/github.com/kontena/pharos-host-upgrades
+
+COPY Gopkg.* ./
+RUN dep ensure -vendor-only
+
+COPY . ./
+RUN GOOS=linux GOARCH=${ARCH} go install -v .
+
+
+# download kubectl
+FROM buildpack-deps:stretch-curl as kube-dl
+ARG ARCH
+
+RUN curl -L -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.3/bin/linux/${ARCH}/kubectl && install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+
+
+FROM scratch
+ARG ARCH
+
+COPY --from=kube-dl /usr/local/bin/kubectl /bin/kubectl
+COPY --from=go-build /go/bin/linux_${ARCH}/pharos-host-upgrades /bin/pharos-host-upgrades
+
+CMD ["/bin/pharos-host-upgrades"]

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -15,7 +15,7 @@ COPY Gopkg.* ./
 RUN dep ensure -vendor-only
 
 COPY . ./
-RUN GOOS=linux GOARCH=${ARCH} go install -v .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go install -v .
 
 
 # download kubectl

--- a/systemd/journal.go
+++ b/systemd/journal.go
@@ -1,0 +1,11 @@
+package systemd
+
+type JournalOptions struct {
+	Unit           string
+	StartTimestamp uint64
+}
+
+type JournalReader interface {
+	Read() ([]string, error)
+	Close() error
+}

--- a/systemd/journal_cgo.go
+++ b/systemd/journal_cgo.go
@@ -1,0 +1,70 @@
+// +build cgo
+
+package systemd
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/coreos/go-systemd/sdjournal"
+)
+
+type journalReader struct {
+	journal *sdjournal.Journal
+}
+
+// open journal for reading, if available
+func OpenJournal(options JournalOptions) (JournalReader, error) {
+	var jr journalReader
+
+	// this silently succeeds if no journal files are available
+	if journal, err := sdjournal.NewJournal(); err != nil {
+		return nil, fmt.Errorf("sdjournal.NewJournal: %v", err)
+	} else {
+		jr.journal = journal
+	}
+
+	if options.Unit == "" {
+
+	} else if err := jr.journal.AddMatch("_SYSTEMD_UNIT=" + options.Unit); err != nil {
+		return nil, fmt.Errorf("sdjournal.AddMatch: %v", err)
+	}
+
+	if options.StartTimestamp == 0 {
+
+	} else if err := jr.journal.SeekRealtimeUsec(options.StartTimestamp); err != nil {
+		return nil, fmt.Errorf("sdjournal.SeekRealtimeUsec: %v", err)
+	}
+
+	return &jr, nil
+}
+
+func (jr *journalReader) Read() ([]string, error) {
+	var lines []string
+
+	log.Printf("systemd/journal: read journal...")
+
+	for {
+		if n, err := jr.journal.Next(); err != nil {
+			return lines, fmt.Errorf("sdjournal.Next: %v", err)
+		} else if n == 0 {
+			break
+		} else if entry, err := jr.journal.GetEntry(); err != nil {
+			return lines, fmt.Errorf("sdjournal.GetEntry: %v", err)
+		} else {
+			var t = time.Unix(int64(entry.RealtimeTimestamp/1e6), int64(entry.RealtimeTimestamp%1e6*1e3))
+			var message = entry.Fields["MESSAGE"]
+
+			log.Printf("systemd/journal: %v %v", t, message)
+
+			lines = append(lines, message)
+		}
+	}
+
+	return lines, nil
+}
+
+func (jr *journalReader) Close() error {
+	return jr.journal.Close()
+}

--- a/systemd/journal_disabled.go
+++ b/systemd/journal_disabled.go
@@ -1,0 +1,7 @@
+// +build !cgo
+
+package systemd
+
+func OpenJournal(options JournalOptions) (JournalReader, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Use `GOARCH=arm64` to cross-compile arm64 images.

These builds lack CGO support, which means no systemd journal support.