### PR TITLE
Fix kubectl drain to use --delete-local-data

### DIFF
--- a/kubectl/drain.go
+++ b/kubectl/drain.go
@@ -1,5 +1,5 @@
 package kubectl
 
 func Drain(node string) error {
-	return kubectl("drain", "--ignore-daemonsets", "--force", node)
+	return kubectl("drain", "--delete-local-data", "--ignore-daemonsets", "--force", node)
 }


### PR DESCRIPTION
Fixes #26 

Can't think of any reason not to use `kubectl drain --delete-local-data` - `emptyDir` volumes should only be used for temporary data. Ideally the pods using local data volumes could be terminated gracefully but left scheduled onto the node for the duration of the reboot instead of being evicted, but lacking any option for that kind of behavior in `kubectl drain`, it doesn't make sense to fail the entire node eviction because of pods with `/tmp` volumes.