### PR TITLE
Use standard cron syntax for --schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,15 @@ command terminated with exit code 2
 
 #### `--schedule`
 
-See https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format
+See https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format (no seconds field).
 
-Variant of a standard crontab with a leading seconds field.
+Standard crontab with five fields (Minutes, Hours, Day of month, Month, Day of week).
 
 Examples:
 
-* `0 15 5 * * *` - every day at 05:15:00
+* `15 5 * * *` - every day at 05:15
+* `1 0 * * SUN` - every sunday at 01:00
+* `@daily` at midnight
 
 #### `--reboot` `--reboot-timeout=...`
 

--- a/resources/daemonset.yml
+++ b/resources/daemonset.yml
@@ -21,7 +21,7 @@ spec:
           command:
             - pharos-host-upgrades
           args:
-            - "--schedule=0 * * * *"
+            - "--schedule=* * * * *"
             - --schedule-window=30s
             - --reboot
             - --drain

--- a/scheduler.go
+++ b/scheduler.go
@@ -27,7 +27,7 @@ func makeScheduler(options Options) (Scheduler, error) {
 		log.Printf("No --schedule given, will run once")
 
 		return scheduler, nil
-	} else if schedule, err := cron.Parse(options.Schedule); err != nil {
+	} else if schedule, err := cron.ParseStandard(options.Schedule); err != nil {
 		return scheduler, fmt.Errorf("Invalid --schedule=%v: %v", options.Schedule, err)
 	} else {
 		scheduler.schedule = schedule


### PR DESCRIPTION
Fixes #29

The `--schedule` option now accepts standard five-field crontab syntax, forcing seconds to 0.

The previous six-field syntax with leading seconds will now be rejected.