### PR TITLE
Add support for debian upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See [`resources`](./resources) for example kube manifests.
 
 ### Supported host OS configurations
 
-#### Ubuntu 16.04
+#### Ubuntu 16.04 & Debia 9.x
 
     apt-get install unattended-upgrades
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Using the vagrant machines:
     $ vagrant up ubuntu
     $ vagrant up centos-7
 
-Note that the `centos/7` box does not support shared folders... vagrant falls back to rsync, so you must `vagrant rsync centos-7` before building the image after any edits.
+Note that the `centos/7` & `debian/stretch64` boxes do not support shared folders... vagrant falls back to rsync, so you must `vagrant rsync centos-7` or `vagrant rsync debian-9` before building the image after any edits.
 
 ### Setup
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,14 @@ Vagrant.configure("2") do |config|
     machine.vm.network "private_network", ip: "192.168.56.12"
   end
 
+  # Debian
+  config.vm.define "debian-9" do |machine|
+    machine.vm.box = "debian/stretch64"
+    machine.vm.hostname = "debian-9"
+    machine.vm.provision "shell", path: 'scripts/vagrant/provision-debian.sh'
+    machine.vm.network "private_network", ip: "192.168.56.12"
+  end
+
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.

--- a/hosts.go
+++ b/hosts.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kontena/pharos-host-upgrades/hosts"
 	"github.com/kontena/pharos-host-upgrades/hosts/centos"
+	"github.com/kontena/pharos-host-upgrades/hosts/debian"
 	"github.com/kontena/pharos-host-upgrades/hosts/ubuntu"
 )
 
@@ -13,6 +14,7 @@ func probeHost(options Options) (hosts.Host, hosts.Info, error) {
 	var probeHosts = []hosts.Host{
 		&ubuntu.Host{},
 		&centos.Host{},
+		&debian.Host{},
 	}
 
 	for _, host := range probeHosts {

--- a/hosts/debian/host.go
+++ b/hosts/debian/host.go
@@ -1,0 +1,193 @@
+package debian
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/kontena/pharos-host-upgrades/hosts"
+	"github.com/kontena/pharos-host-upgrades/proc"
+	"github.com/kontena/pharos-host-upgrades/systemd"
+)
+
+const OperatingSystem = "Debian"
+
+var osPrettyNameRegexp = regexp.MustCompile(`Debian (\S+)( LTS)?`)
+
+type aptConfVars struct {
+	ConfigPath string
+}
+
+// because of how lists in apt configs are merged, the unattended-upgrades.conf must be loaded last to allow overriding the Unattended-Upgrade::Allowed-Origins list
+// use a generated APT_CONFIG=... file to load the given unattended-upgrades.conf using Dir::Etc::main after the Dir::Etc::Parts
+// this assumes that /etc/apt.conf does not exist, or does not contain anything important...
+const aptConfTemplate = `
+Dir::Etc::main "{{.ConfigPath}}";
+`
+
+const upgradeScript = `
+set -ue
+
+apt-get update
+
+unattended-upgrade -v > $HOST_PATH/unattended-upgrade.out
+
+if [ -e /run/reboot-required ]; then
+	# preserve timestamp
+	cp -a /run/reboot-required $HOST_PATH/reboot-required
+fi
+
+# TODO: also restart for service upgrades?
+# which needrestart && needrestart -b > $HOST_PATH/needrestart
+`
+
+type Host struct {
+	info   hosts.Info
+	config hosts.Config
+
+	configPath    string
+	aptConfigPath string
+	scriptPath    string
+}
+
+func (host *Host) Probe() (hosts.Info, bool) {
+	if hi, err := systemd.GetHostInfo(); err != nil {
+		log.Printf("hosts/debian probe failed: %v", err)
+
+		return host.info, false
+	} else if match := osPrettyNameRegexp.FindStringSubmatch(hi.OperatingSystemPrettyName); match == nil {
+		log.Printf("hosts/debian probe mismatch: %v", hi.OperatingSystemPrettyName)
+
+		return host.info, false
+	} else {
+		host.info = hosts.Info{
+			OperatingSystem:        OperatingSystem,
+			OperatingSystemRelease: match[1],
+			Kernel:                 hi.KernelName,
+			KernelRelease:          hi.KernelRelease,
+		}
+
+		if procStat, err := proc.ReadStat(); err != nil {
+			log.Printf("hosts/debian failed stat BootTime: %v", err)
+		} else {
+			log.Printf("hosts/debian boot time: %v", procStat.BootTime)
+
+			host.info.BootTime = procStat.BootTime
+		}
+
+		log.Printf("hosts/debian probe success: %#v", host.info)
+
+		return host.info, true
+	}
+}
+
+func (host *Host) String() string {
+	return fmt.Sprintf("%v %v", host.info.OperatingSystem, host.info.OperatingSystemRelease)
+}
+
+func (host *Host) Config(config hosts.Config) error {
+	host.config = config // used for reading output...
+
+	if hostPath := config.HostPath(); hostPath == "" {
+		return fmt.Errorf("hosts/debian requires --host-path")
+	} else {
+		log.Printf("hosts/debian: using host path %v for output files", hostPath)
+	}
+
+	if exists, err := config.FileExists("unattended-upgrades.conf"); err != nil {
+		return err
+	} else if !exists {
+		log.Printf("hosts/debian: no unattended-upgrades.conf configured")
+	} else if configPath, err := config.CopyHostFile("unattended-upgrades.conf"); err != nil {
+		return fmt.Errorf("hosts/debian failed to CopyHostFile unattended-upgrades.conf: %v", err)
+	} else {
+		log.Printf("hosts/debian: using copied unattended-upgrades.conf at %v", configPath)
+
+		host.configPath = configPath
+	}
+
+	if host.configPath == "" {
+
+	} else if path, err := config.GenerateFile("apt.conf", aptConfTemplate, aptConfVars{ConfigPath: host.configPath}); err != nil {
+		return fmt.Errorf("hosts/debian failed to GenerateFile apt.conf: %v", err)
+	} else {
+		host.aptConfigPath = path
+	}
+
+	// debian has /run mounted noexec, so no point making this executable...
+	if path, err := config.WriteHostFile("host-upgrades.sh", bytes.NewReader([]byte(upgradeScript))); err != nil {
+		return err
+	} else {
+		log.Printf("hosts/debian: using generated host-upgrades.sh at %v", path)
+
+		host.scriptPath = path
+	}
+
+	return nil
+}
+
+func (host *Host) exec(env []string, cmd []string) error {
+	if _, err := systemd.Exec("host-upgrades", systemd.ExecOptions{Env: env, Cmd: cmd}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (host *Host) readRebootRequired(status *hosts.Status) error {
+	var buf bytes.Buffer
+
+	if stat, exists, err := host.config.StatHostFile("reboot-required"); err != nil {
+		return err
+	} else if !exists {
+
+	} else if err := host.config.ReadHostFile("reboot-required", &buf); err != nil {
+		return err
+	} else {
+		status.RebootRequired = true
+		status.RebootRequiredSince = stat.ModTime()
+		status.RebootRequiredMessage = buf.String()
+	}
+
+	return nil
+}
+
+func (host *Host) readUpgradeLog(status *hosts.Status) error {
+	var buf bytes.Buffer
+
+	if err := host.config.ReadHostFile("unattended-upgrade.out", &buf); err != nil {
+		return err
+	} else {
+		status.UpgradeLog = buf.String()
+	}
+
+	return nil
+}
+
+func (host *Host) Upgrade() (hosts.Status, error) {
+	var status hosts.Status
+	var env = []string{
+		"HOST_PATH=" + host.config.HostPath(),
+		"APT_CONFIG=" + host.aptConfigPath,
+	}
+	var cmd = []string{"/bin/sh", "-x", host.scriptPath}
+
+	log.Printf("hosts/debian upgrade...")
+
+	if err := host.exec(env, cmd); err != nil {
+		return status, err
+	} else if err := host.readUpgradeLog(&status); err != nil {
+		return status, err
+	} else if err := host.readRebootRequired(&status); err != nil {
+		return status, err
+	} else {
+		return status, nil
+	}
+}
+
+func (host *Host) Reboot() error {
+	log.Printf("hosts/debian reboot...")
+
+	return systemd.Reboot()
+}

--- a/scripts/vagrant/provision-debian.sh
+++ b/scripts/vagrant/provision-debian.sh
@@ -1,0 +1,56 @@
+set -uex
+
+apt-get update
+apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/docker.gpg
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/kubernetes.gpg
+
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+
+cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+
+apt-get update
+apt-get install -y docker-ce
+apt-get install -y kubelet kubeadm kubectl
+apt-get install -y unattended-upgrades
+
+cat <<EOF >/etc/docker/daemon.json
+{
+    "storage-driver": "overlay2"
+}
+EOF
+
+test -d /etc/cni/net.d || mkdir -p /etc/cni/net.d
+cat <<EOF >/etc/cni/net.d/bridge.json
+{
+	"name": "cni",
+	"type": "bridge",
+	"bridge": "cni",
+	"isDefaultGateway": true,
+	"forceAddress": false,
+	"ipMasq": true,
+	"hairpinMode": true,
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.10.1.0/24"
+	}
+}
+EOF
+
+adduser vagrant docker
+
+swapoff -a
+
+test -e /etc/kubernetes/admin.conf || kubeadm init
+test -e ~/.kube || mkdir ~/.kube
+cat /etc/kubernetes/admin.conf > ~/.kube/config


### PR DESCRIPTION
Mostly what we had already for Ubuntu as they both use `apt`.

## Some testing
Before running host-upgrader:

```
$ uname -a
Linux debian-9 4.9.0-7-amd64 #1 SMP Debian 4.9.110-1 (2018-07-05) x86_64 GNU/Linux
```
Run host-upgrader:
```
root@debian-9:/vagrant# docker run --rm --name host-upgrades --privileged   -v $PWD/config:/etc/host-upgrades   -v /run/host-upgrades:/run/host-upgrades   -v /var/run/dbus:/var/run/dbus   -v /run/log/journal:/run/log/journal   kontena/pharos-host-upgrades:dev /usr/local/bin/pharos-host-upgrades -v 9 -reboot
2018/10/02 12:14:04 pharos-host-upgrades version 0.2.0 (Go go1.10.2)
2018/10/02 12:14:04 Load config from --config-path=/etc/host-upgrades
2018/10/02 12:14:04 Copying configs to --host-mount=/run/host-upgrades
2018/10/02 12:14:04 hosts/ubuntu probe mismatch: Debian GNU/Linux 9 (stretch)
2018/10/02 12:14:04 hosts/centos probe mismatch: Debian GNU/Linux 9 (stretch)
2018/10/02 12:14:04 hosts/debian boot time: 2018-10-02 11:54:14 +0000 UTC
2018/10/02 12:14:04 hosts/debian probe success: hosts.Info{OperatingSystem:"Debian", OperatingSystemRelease:"GNU/Linux", Kernel:"Linux", KernelRelease:"4.9.0-7-amd64", BootTime:time.Time{wall:0x0, ext:63674078054, loc:(*time.Location)(0x1813020)}}
2018/10/02 12:14:04 Probed host: Debian GNU/Linux
2018/10/02 12:14:04 hosts/debian: using host path /run/host-upgrades for output files
2018/10/02 12:14:04 hosts/debian: using copied unattended-upgrades.conf at /run/host-upgrades/unattended-upgrades.conf
2018/10/02 12:14:04 hosts/debian: using generated host-upgrades.sh at /run/host-upgrades/host-upgrades.sh
2018/10/02 12:14:04 No --schedule given, will run once
2018/10/02 12:14:04 No --kube configuration
2018/10/02 12:14:04 Using --reboot, will reboot host after upgrades if required
2018/10/02 12:14:04 Skip kube locking
2018/10/02 12:14:04 Running host upgrades...
2018/10/02 12:14:04 hosts/debian upgrade...
2018/10/02 12:14:04 systemd/exec host-upgrades.service: systemd.ExecOptions{Unit:"host-upgrades.service", Cmd:[]string{"/bin/sh", "-x", "/run/host-upgrades/host-upgrades.sh"}, Env:[]string{"HOST_PATH=/run/host-upgrades", "APT_CONFIG=/run/host-upgrades/apt.conf"}}
2018/10/02 12:14:04 systemd/exec host-upgrades.service: reset
2018/10/02 12:14:04 systemd/exec host-upgrades.service: start []dbus.Property{dbus.Property{Name:"Type", Value:dbus.Variant{sig:dbus.Signature{str:"s"}, value:"oneshot"}}, dbus.Property{Name:"Environment", Value:dbus.Variant{sig:dbus.Signature{str:"as"}, value:[]string{"HOST_PATH=/run/host-upgrades", "APT_CONFIG=/run/host-upgrades/apt.conf"}}}, dbus.Property{Name:"ExecStart", Value:dbus.Variant{sig:dbus.Signature{str:"a(sasb)"}, value:[]dbus.execStart{dbus.execStart{Path:"/bin/sh", Args:[]string{"/bin/sh", "-x", "/run/host-upgrades/host-upgrades.sh"}, UncleanIsFailure:false}}}}}
2018/10/02 12:14:04 systemd/exec host-upgrades.service: wait...
2018/10/02 12:14:11 systemd/exec host-upgrades.service: done, status=done
2018/10/02 12:14:11 systemd/journal: read journal...
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:04.473651 +0000 UTC + set -ue
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:04.473651 +0000 UTC + apt-get update
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:04.637302 +0000 UTC Ign:1 http://deb.debian.org/debian stretch InRelease
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:04.661622 +0000 UTC Hit:2 http://deb.debian.org/debian stretch Release
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:04.790722 +0000 UTC Hit:3 http://security.debian.org/debian-security stretch/updates InRelease
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:04.9678 +0000 UTC Hit:5 https://download.docker.com/linux/debian stretch InRelease
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:05.341929 +0000 UTC Hit:6 https://packages.cloud.google.com/apt kubernetes-xenial InRelease
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:06.098891 +0000 UTC Reading package lists...
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:06.126974 +0000 UTC + unattended-upgrade -v
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:11.512769 +0000 UTC debug: running /usr/lib/os-probes/50mounted-tests on /dev/sda2
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:11.522965 +0000 UTC debug: /dev/sda2 type not recognised; skipping
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:11.524933 +0000 UTC debug: os detected by /usr/lib/os-probes/50mounted-tests
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:11.530142 +0000 UTC debug: running /usr/lib/os-probes/50mounted-tests on /dev/sda5
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:11.536049 +0000 UTC debug: /dev/sda5 is a swap partition; skipping
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:11.537881 +0000 UTC debug: os detected by /usr/lib/os-probes/50mounted-tests
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:11.858785 +0000 UTC + [ -e /run/reboot-required ]
2018/10/02 12:14:11 systemd/journal: 2018-10-02 12:14:11.858785 +0000 UTC + cp -a /run/reboot-required /run/host-upgrades/reboot-required
2018/10/02 12:14:11 systemd/exec host-upgrades.service: done
2018/10/02 12:14:11 Skip updating kube node condition
2018/10/02 12:14:11 Reboot required, rebooting without draining kube node...
2018/10/02 12:14:11 hosts/debian reboot...
Connection to 127.0.0.1 closed by remote host.
Connection to 127.0.0.1 closed.
```

After reboot:
```
root@debian-9:~# uname -a
Linux debian-9 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u5 (2018-09-30) x86_64 GNU/Linux
```

